### PR TITLE
Fix mixed types in remaining calls

### DIFF
--- a/truvari/collapse.py
+++ b/truvari/collapse.py
@@ -27,7 +27,7 @@ def collapse_chunk(chunk):
     logging.debug(f"Comparing chunk {calls}")
     calls.sort(reverse=True, key=matcher.sorter)
 
-    # keep_key : [keep entry, [collap entries], match_id]
+    # keep_key : [keep entry, [collap matches], match_id]
     ret = {}
     # collap_key : keep_key
     chain_lookup = {}
@@ -67,9 +67,9 @@ def collapse_chunk(chunk):
         # Only put in the single best match
         # Leave the others to be handled later
         if matcher.hap and ret[keep_key][1]:
-            candidates = sorted(ret[keep_key][1], reverse=True)
-            ret[keep_key][1] = [candidates.pop(0)]
-            remaining_calls.extend(candidates)
+            mats = sorted(ret[keep_key][1], reverse=True)
+            ret[keep_key][1] = [mats.pop(0)]
+            remaining_calls.extend(mat.comp for mat in mats)
 
         calls = remaining_calls
 


### PR DESCRIPTION
Two different types (`VariantRecord` and `MatchResult`) are in `remaining_calls` when there are multiple matches (see an example VCF below), which causes `truvari collapse` to panic.

```
chr1	50694004	INS.1	T	TATATACATGACATATATGACATATATATGACATATACATGACATACATGAC	60	.	SVTYPE=INS;END=50694004;SVLEN=51	GT	0|1
chr1	50694004	INS.2	T	TATATACATGACATATATGACATATATATGACATATACATGACATACCCCCC	60	.	SVTYPE=INS;END=50694004;SVLEN=51	GT	1|0
chr1	50694004	INS.3	T	TATATACATGACATATATGACATATATATGACATATACATGACATACATCAC	60	.	SVTYPE=INS;END=50694004;SVLEN=51	GT	1|0
```