### PR TITLE
Use generator instead of list in `create_file_intersections()` to save memory

### DIFF
--- a/truvari/consistency_report.py
+++ b/truvari/consistency_report.py
@@ -81,8 +81,8 @@ def create_file_intersections(allVCFs):
     Generate all possible intersections of vcfs
     """
     count_lookup = {}
-    combo_gen = [x for l in range(1, len(allVCFs) + 1)
-                 for x in itertools.combinations(allVCFs, l)]
+    combo_gen = (x for l in range(1, len(allVCFs) + 1)
+                 for x in itertools.combinations(allVCFs, l))
     for files_combo in combo_gen:
         files_combo = hash_list(files_combo)
         files_combo.sort()


### PR DESCRIPTION
I have 70+ vcfs. While running consistency, it complains about memory usage with the list used in `create_file_intersections()`. Using a generator solves it.