### PR TITLE
Update comparisons.py to sovle the TypeError caused by type of "SVLEN"

### DIFF
--- a/truvari/comparisons.py
+++ b/truvari/comparisons.py
@@ -313,7 +313,7 @@ def entry_size(entry):
     """
     if "SVLEN" in entry.info:
         if type(entry.info["SVLEN"]) in [list, tuple]:
-            size = abs(entry.info["SVLEN"][0])
+            size = abs(int(entry.info["SVLEN"][0]))
         else:
             size = abs(entry.info["SVLEN"])
     elif entry.alts is not None and entry.alts[0].count("<"):


### PR DESCRIPTION
I got the following error when I used truvari:
```
 File "/data/home/user/miniconda3/envs/truvari/lib/python3.7/site-packages/truvari/comparisons.py", line 424, in entry_size
 size = abs(entry.info["SVLEN"][0])
 TypeError: bad operand type for abs(): 'str'
```
The "SVLEN" content in  vcf header is: 

```
##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="Variant length"> 
```

