### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get -qq update \
   rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /opt/truvari-source/truvari/
-COPY setup.py README.md /opt/truvari-source
+COPY setup.py README.md /opt/truvari-source/
 COPY truvari/ /opt/truvari-source/truvari/
 WORKDIR /opt/truvari-source
 


### PR DESCRIPTION
I ran into this error running the docker build today (docker 20.10.11)

```
Step 4/10 : COPY setup.py README.md /opt/truvari-source
When using COPY with more than one source file, the destination must be a directory and end with a /
```

