### PR TITLE
Update Dockerfile to install dependent python packages.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get -qq update \
   rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /opt/truvari-source/truvari/
-COPY setup.py README.md /opt/truvari-source/
+COPY setup.py README.md pyproject.toml /opt/truvari-source/
 COPY truvari/ /opt/truvari-source/truvari/
 WORKDIR /opt/truvari-source
 


### PR DESCRIPTION
Sorry for the piecemeal update, in the last update docker finished building without error but I didn't actually test running truvari thought it yet. Looks like the project toml needs to be copied over for all the python dependencies to be picked up by pip.